### PR TITLE
Add support for custom mermaid.initialize() options. 

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,11 @@ extensions = [
 
 ### Config Options
 
-mermaid_init
-: Set to a dictionary of values to pass to `mermaid.initialize()`.
+``mermaid_init``
+
+Set to a dictionary of values to pass to `mermaid.initialize()`.
+
+Example:
 
 ```python
 mermaid_init = {

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Example:
 ```python
 mermaid_init = {
   'theme': 'base',
-  'themeOptions': {
+  'themeVariables': {
     'primaryColor': '#BB2528',
     'primaryTextColor': '#fff',
     'primaryBorderColor': '#7C0000',

--- a/README.md
+++ b/README.md
@@ -23,6 +23,25 @@ extensions = [
 ]
 ```
 
+### Config Options
+
+mermaid_init
+: Set to a dictionary of values to pass to `mermaid.initialize()`.
+
+```python
+mermaid_init = {
+  'theme': 'base',
+  'themeOptions': {
+    'primaryColor': '#BB2528',
+    'primaryTextColor': '#fff',
+    'primaryBorderColor': '#7C0000',
+    'lineColor': '#F8B229',
+    'secondaryColor': '#006100',
+    'tertiaryColor': '#fff'
+  }
+}
+```
+
 ## Usage
 
 In your `rst` (or `md`) files, use the directive just like:

--- a/README.md
+++ b/README.md
@@ -25,9 +25,8 @@ extensions = [
 
 ### Config Options
 
-``mermaid_init``
-
-Set to a dictionary of values to pass to `mermaid.initialize()`. Find more info
+`mermaid_init` can be set as a dictionary of values. 
+These will be passed to `mermaid.initialize()`. Find more info
 at [MermaidJS](https://mermaid.js.org/intro/n00b-syntaxReference.html)
 
 Example:

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ extensions = [
 
 ### Config Options
 
-``mermaid_init``
+``sphinxmermaid_mermaid_init``
 
 Set to a dictionary of values to pass to `mermaid.initialize()`. Find more info
 at [MermaidJS](https://mermaid.js.org/intro/n00b-syntaxReference.html)
@@ -33,7 +33,7 @@ at [MermaidJS](https://mermaid.js.org/intro/n00b-syntaxReference.html)
 Example:
 
 ```python
-mermaid_init = {
+sphinxmermaid_mermaid_init = {
   'theme': 'base',
   'themeOptions': {
     'primaryColor': '#BB2528',

--- a/README.md
+++ b/README.md
@@ -27,7 +27,8 @@ extensions = [
 
 ``mermaid_init``
 
-Set to a dictionary of values to pass to `mermaid.initialize()`.
+Set to a dictionary of values to pass to `mermaid.initialize()`. Find more info
+at [MermaidJS](https://mermaid.js.org/intro/n00b-syntaxReference.html)
 
 Example:
 

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -69,9 +69,7 @@ def install_js(app: "Sphinx", *_):
     """
     LOGGER.debug("Installing mermaid JavaScript from %s", MERMAID_JS_URL)
     app.add_js_file(MERMAID_JS_URL, priority=500)
-
-    mermaid_init = create_mermaid_init(app)
-    app.add_js_file(None, body=mermaid_init, priority=501)
+    app.add_js_file(None, body=create_mermaid_init(app), priority=501)
 
 
 def create_mermaid_init(app: "Sphinx"):
@@ -79,15 +77,11 @@ def create_mermaid_init(app: "Sphinx"):
     Returns the `mermaid.initialize({...})` code string from the value
     specified in conf.py or the default value.
     """
-
     mermaid_init = app.config.mermaid_init
-
     if mermaid_init:
         check_mermaid_init(mermaid_init)
-
         params = json.dumps(mermaid_init)
         return f"mermaid.initialize({params})"
-
     return DEFAULT_MERMAID_INIT
 
 
@@ -95,7 +89,6 @@ def check_mermaid_init(mermaid_init):
     """
     Checks whether `mermaid_init` is valid. If not, raises an error.
     """
-
     if not isinstance(mermaid_init, dict):
         raise TypeError("mermaid_init must be a dict.")
 

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -13,7 +13,7 @@ from sphinx.util.docutils import SphinxDirective
 
 LOGGER = logging.getLogger(__name__)
 MERMAID_JS_URL = "https://unpkg.com/mermaid/dist/mermaid.min.js"
-DEFAULT_MERMAID_INIT = "mermaid.initialize({startOnLoad:true});"
+DEFAULT_MERMAID_INIT = {"startOnLoad": True}
 
 if TYPE_CHECKING:
     from docutils.nodes import Node
@@ -77,12 +77,13 @@ def create_mermaid_init(app: "Sphinx"):
     Returns the `mermaid.initialize({...})` code string from the value
     specified in conf.py or the default value.
     """
-    mermaid_init = app.config.mermaid_init
-    if mermaid_init:
+    if app.config.mermaid_init is not None:
+        mermaid_init = app.config.mermaid_init
         check_mermaid_init(mermaid_init)
-        params = json.dumps(mermaid_init)
-        return f"mermaid.initialize({params})"
-    return DEFAULT_MERMAID_INIT
+    else:
+        mermaid_init = DEFAULT_MERMAID_INIT
+    params = json.dumps(mermaid_init)
+    return f"mermaid.initialize({params})"
 
 
 def check_mermaid_init(mermaid_init):

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -2,6 +2,7 @@
 Main file of the sphinx extension
 """
 
+import json
 from typing import TYPE_CHECKING, List
 
 import sphinx
@@ -68,13 +69,29 @@ def install_js(app: "Sphinx", *_):
     """
     LOGGER.debug("Installing mermaid JavaScript from %s", MERMAID_JS_URL)
     app.add_js_file(MERMAID_JS_URL, priority=500)
-    app.add_js_file(None, body=JS_INIT_MERMAID, priority=501)
+
+    mermaid_init = create_mermaid_init(app)
+    app.add_js_file(None, body=mermaid_init, priority=501)
+
+
+def create_mermaid_init(app):
+    """
+    Returns the `mermaid.initialize({...})` code string from the value
+    specified in conf.py or the default value.
+    """
+
+    if app.config.mermaid_init:
+        params = json.dumps(app.config.mermaid_init)
+        return f"mermaid.initialize({params})"
+
+    return JS_INIT_MERMAID
 
 
 def setup(app: "Sphinx"):
     """
     Setup the extension
     """
+    app.add_config_value("mermaid_init", None, "html")
     app.add_node(MermaidNode, html=(html_mermaid, None))
     app.add_directive("mermaid", Mermaid)
     app.connect("html-page-context", install_js)

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -74,7 +74,7 @@ def install_js(app: "Sphinx", *_):
     app.add_js_file(None, body=mermaid_init, priority=501)
 
 
-def create_mermaid_init(app):
+def create_mermaid_init(app: "Sphinx"):
     """
     Returns the `mermaid.initialize({...})` code string from the value
     specified in conf.py or the default value.

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -77,8 +77,8 @@ def create_mermaid_init(app: "Sphinx"):
     Returns the `mermaid.initialize({...})` code string from the value
     specified in conf.py or the default value.
     """
-    if app.config.mermaid_init is not None:
-        mermaid_init = app.config.mermaid_init
+    if app.config.sphinxmermaid_mermaid_init is not None:
+        mermaid_init = app.config.sphinxmermaid_mermaid_init
         check_mermaid_init(mermaid_init)
     else:
         mermaid_init = DEFAULT_MERMAID_INIT
@@ -98,7 +98,7 @@ def setup(app: "Sphinx"):
     """
     Setup the extension
     """
-    app.add_config_value("mermaid_init", None, "html")
+    app.add_config_value("sphinxmermaid_mermaid_init", None, "html")
     app.add_node(MermaidNode, html=(html_mermaid, None))
     app.add_directive("mermaid", Mermaid)
     app.connect("html-page-context", install_js)

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -80,11 +80,24 @@ def create_mermaid_init(app):
     specified in conf.py or the default value.
     """
 
-    if app.config.mermaid_init:
-        params = json.dumps(app.config.mermaid_init)
+    mermaid_init = app.config.mermaid_init
+
+    if mermaid_init:
+        check_mermaid_init(mermaid_init)
+
+        params = json.dumps(mermaid_init)
         return f"mermaid.initialize({params})"
 
     return DEFAULT_MERMAID_INIT
+
+
+def check_mermaid_init(mermaid_init):
+    """
+    Checks whether `mermaid_init` is valid. If not, raises an error.
+    """
+
+    if not isinstance(mermaid_init, dict):
+        raise TypeError("mermaid_init must be a dict.")
 
 
 def setup(app: "Sphinx"):

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -91,7 +91,7 @@ def check_mermaid_init(mermaid_init):
     Checks whether `mermaid_init` is valid. If not, raises an error.
     """
     if not isinstance(mermaid_init, dict):
-        raise TypeError("mermaid_init must be a dict.")
+        raise TypeError("'sphinxmermaid_mermaid_init' must be a dict.")
 
 
 def setup(app: "Sphinx"):

--- a/sphinxmermaid/__init__.py
+++ b/sphinxmermaid/__init__.py
@@ -13,7 +13,7 @@ from sphinx.util.docutils import SphinxDirective
 
 LOGGER = logging.getLogger(__name__)
 MERMAID_JS_URL = "https://unpkg.com/mermaid/dist/mermaid.min.js"
-JS_INIT_MERMAID = "mermaid.initialize({startOnLoad:true});"
+DEFAULT_MERMAID_INIT = "mermaid.initialize({startOnLoad:true});"
 
 if TYPE_CHECKING:
     from docutils.nodes import Node
@@ -84,7 +84,7 @@ def create_mermaid_init(app):
         params = json.dumps(app.config.mermaid_init)
         return f"mermaid.initialize({params})"
 
-    return JS_INIT_MERMAID
+    return DEFAULT_MERMAID_INIT
 
 
 def setup(app: "Sphinx"):


### PR DESCRIPTION
I wanted to update the theme of my mermaid charts, but that required a custom argument to `mermaid.initialize()`.

I added a configuration options `mermaid_init` to be added to `conf.py` that can hold a dictionary of options to be passed to `mermaid.initialize`. When the JS files are being added to the app, I check if the configuration option is set. If it is, I use `json.dumps()` to convert the dictionary to a JSON string compatible with JavaScript. Otherwise, I use the default initialization string.

One pitfall with this approach is that there is no verification that the values within `mermaid_init` are compatible in JavaScript after the JSON dump. 

Additionally, I updated the build process to use a VERSION file that can be version controlled itself instead of an environment variable. This way, the version associated with any release can be verified within the source code.